### PR TITLE
Fix the problems occurred from the gcc -fasnitize option set

### DIFF
--- a/src/include/type/byte_array.h
+++ b/src/include/type/byte_array.h
@@ -82,7 +82,7 @@ class GenericArray {
 
   // corresponds to "bar = null;" in Java
   void reset() {
-    data_.reset();
+    if (data_ != nullptr) data_.reset();
     length_ = -1;
   };
 

--- a/test/gc/transaction_level_gc_manager_test.cpp
+++ b/test/gc/transaction_level_gc_manager_test.cpp
@@ -50,7 +50,7 @@ TEST_F(TransactionLevelGCManagerTests, StartGC) {
   gc_manager.StartGC(gc_threads);
   EXPECT_TRUE(gc_manager.GetStatus() == true);
 
-  std::this_thread::sleep_for(std::chrono::microseconds(100));
+  std::this_thread::sleep_for(std::chrono::microseconds(1000));
 
   gc_manager.StopGC();
   EXPECT_TRUE(gc_manager.GetStatus() == false);


### PR DESCRIPTION
I just tested random issues with GenericArray and GC, and fixed them. I did not try all the tests, so there may be issues other than these. These fixes pass array_value_test and transaction_level_gc_manager_test. I will add to this PR if I find more.